### PR TITLE
Generated function expression should have `expression: false`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -429,7 +429,7 @@ function generateClassDefinitionExpression(node) {
       null,
       superClassId ? [superClassId] : [],
       b.blockStatement(definitionStatements),
-      false, true, false
+      false, false, false
     ),
     superClassId ? [node.superClass] : []
   ));


### PR DESCRIPTION
Currently generated `FunctionExpression` contains `expression: true` which is ES6-only property intended to be used for arrow functions which contain single expression as body (instead of block of statements).

This confuses `escodegen` which tries to generate single expression from function's body but finds `BlockStatement` thus failing with `Error: Unknown expression type: BlockStatement`.
